### PR TITLE
update iconv-lite dependency to ~0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,20 +11,20 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "~2.4.1",
-    "iconv-lite": "~0.2.11",
-    "rimraf": "~2.2.2",
-    "glob": "~3.2.6",
-    "minimatch": "~0.2.12",
     "findup-sync": "~0.1.2",
-    "isbinaryfile": "~2.0.1"
+    "glob": "~3.2.6",
+    "iconv-lite": "~0.4.3",
+    "isbinaryfile": "~2.0.1",
+    "lodash": "~2.4.1",
+    "minimatch": "~0.2.12",
+    "rimraf": "~2.2.2"
   },
   "devDependencies": {
-    "temporary": "~0.0.4",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-release": "~0.6.0"
+    "grunt-release": "~0.6.0",
+    "temporary": "~0.0.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I know this seems like a trivial pull request but I'm working on packaging up [Groove Basin](https://github.com/andrewrk/groovebasin/) for Debian, which indirectly depends on the `iconv-lite` module twice, with conflicting versions. NPM handles these version conflicts by simultaneously depending on multiple versions, while Debian requires that there be only one version of everything for security reasons. Fortunately, the solution is simple - if `file-utils` updates to the latest version of `iconv-lite` then everybody is happy.

Unfortunately I was not able to verify that the tests still pass, this is what happens when I run `npm test`:

```
> grunt test

sh: 1: grunt: not found
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
